### PR TITLE
lens behavior at image edge and corners issue fixed

### DIFF
--- a/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.css
+++ b/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.css
@@ -9,6 +9,7 @@
 }
 
 .img-zoom-lens {
+  pointer-events: none;
   position: absolute;
   border: 1px solid #d4d4d4;
   /*set the size of the lens:*/

--- a/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.html
+++ b/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.html
@@ -1,5 +1,5 @@
 <div  class="img-zoom-container" #container libMouseWheel (mouseWheelUp)="handleZoomInOnMouseWheelUp()" (mouseWheelDown)="handleZoomOutOnMouseWheelUp()">
-    <img id="myimage" [src]="previewImage" #img (mouseleave)="handleMouseLeave()">
+    <img id="myimage" class ='cursor-crosshair' [src]="previewImage" #img (mouseleave)="handleMouseLeave()">
     <div [ngClass]="{'hide': hide || !showResult}" 
         id="myresult" 
         class="img-zoom-result" 

--- a/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.ts
+++ b/projects/ngx-img-zoom/src/lib/ngx-img-zoom.component.ts
@@ -123,10 +123,6 @@ export class NgxImgZoomComponent implements OnInit, AfterViewInit {
     this.renderer.setAttribute(this.container, 'style', <string>this.containerStyle);
     this.imageZoom();
     this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-    this.renderer.listen(this.img, 'mouseout', () => {
-      this.hide = true;
-      this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-     });
   }
 
 
@@ -135,12 +131,12 @@ export class NgxImgZoomComponent implements OnInit, AfterViewInit {
     if (!this.lens) {
       this.lens = this.renderer.createElement('DIV');
       this.renderer.addClass(this.lens, 'img-zoom-lens');
-      this.renderer.addClass(this.lens, 'cursor-crosshair');
+      // this.renderer.addClass(this.lens, 'cursor-crosshair');
       this.renderer.insertBefore(this.img.parentElement, this.lens, this.img);
     }
-    this.renderer.setAttribute(this.lens, 'style', <string>this.lensStyle);
 
     /*insert lens:*/
+    this.renderer.setAttribute(this.lens, 'style', <string>this.lensStyle);
 
     /*calculate the ratio between result DIV and lens:*/
       this.cx = this.result.offsetWidth / this.lens.offsetWidth;
@@ -173,32 +169,24 @@ export class NgxImgZoomComponent implements OnInit, AfterViewInit {
 
 
       /*prevent the lens from being positioned outside the image:*/
-      if (x > this.img.width - this.lens.offsetWidth / 2) {
+      if (x > this.img.width - this.lens.offsetWidth) {
         x = this.img.width - this.lens.offsetWidth;
-        this.hide = true;
-        this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-      } else if (x < 0 - this.lens.offsetHeight / 2) {
+      } else if (x < 0) {
         x = 0;
-        this.hide = true;
-        this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-      } else if (y > this.img.height - this.lens.offsetHeight / 2) {
+      } 
+       if (y > this.img.height - this.lens.offsetHeight) {
         y = this.img.height - this.lens.offsetHeight;
-        this.hide = true;
-        this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-      } else if (y < 0 - this.lens.offsetHeight / 2) {
+      } else if (y < 0 ) {
         y = 0;
-        this.hide = true;
-        this.renderer.setStyle(this.lens, 'visibility', 'hidden');
-      } else if ((y <= this.img.height - this.lens.offsetHeight) && (x <= this.img.width - this.lens.offsetWidth) && y > 0 && x > 0) {
-          this.hide = false;
-          if (this.showResult) {
-            this.renderer.setStyle(this.lens, 'left', x + 'px');
-            this.renderer.setStyle(this.lens, 'top', y + 'px');
-            /*display what the lens 'sees':*/
-            this.renderer.setStyle(this.result, 'backgroundPosition', '-' + (x * this.cx) + 'px -' + (y * this.cy) + 'px');
-            this.renderer.setStyle(this.lens, 'visibility', 'visible');
-          }
-        }
+      } 
+      this.hide = false;
+      if (this.showResult) {
+        this.renderer.setStyle(this.lens, 'left', x + 'px');
+        this.renderer.setStyle(this.lens, 'top', y + 'px');
+        /*display what the lens 'sees':*/
+        this.renderer.setStyle(this.result, 'backgroundPosition', '-' + (x * this.cx) + 'px -' + (y * this.cy) + 'px');
+        this.renderer.setStyle(this.lens, 'visibility', 'visible');
+      }
     }
 
   getCursorPos(e) {


### PR DESCRIPTION
fixes #11 
fixes #7 
Instead of setting hide=true at x=0, y=0 etc, I only set the correct position of the lens there.
Then to hide resultant image and lens when cursor goes out of source image, I used 'mouseleave' event on source image (also removed 'mouseout' event on source image since its bubbling behavior causes issues).
Now, since the lens comes over the source image, it creates problems for the detection of 'mouseleave'. So I set 'pointer-events:none' for lens. Now, the cursor can communicate with the source image without any problem. 
Also, directly added class of crosshair to source image since it cannot be applied to lens anymore since pointer events are disabled on it.

![correctedCornerZoom4](https://user-images.githubusercontent.com/25122531/66429303-675fab00-ea35-11e9-991b-ab1fd5527071.gif)